### PR TITLE
Update main.py

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -381,7 +381,10 @@ elif upload_protocol in debug_tools:
         # normal firmware upload. flash starts at 0x10000000
         openocd_args.extend([
             "-c", "program {$SOURCE} %s verify reset; shutdown;" %
-            board.get("upload.offset_address", "0x10000000")
+            # board.get("upload.offset_address", "0x10000000")
+            board.get("upload.offset_address", "") 
+           #because of the logic selecting elf or firm (bin), we need to default to no offset because we already defaulted to elf a few lines below when no offset is needed
+           # programming fails otherwise
         ])
     openocd_args = [
         f.replace("$PACKAGE_DIR", platform.get_package_dir(


### PR DESCRIPTION
 because of the logic selecting elf or firm (bin), we need to default to no offset on normal firmware upload because we already defaulted to elf a few lines below if upload.offset_address is not user set so when no offset is needed. 
programming fails otherwise
Unfortunately, my way of modifying the code probably sucks because I've never written anything in python but I assumed the second arg is the default n case the first is missing. Haven't had time to dig too much into it.