### PR TITLE
Update toolchain

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -35,7 +35,7 @@
       "type": "toolchain", 
       "optional": true,
       "owner": "earlephilhower",
-      "version": "5.100300.221223"
+      "version": "5.100300.230216"
     },
     "framework-arduino-mbed": {
       "type": "framework",


### PR DESCRIPTION
The old version doesn't exist on PIO anymore, causing build failures.