### PR TITLE
Enable BlackMagicProbe support

### DIFF
--- a/boards/0xcb_helios.json
+++ b/boards/0xcb_helios.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_feather.json
+++ b/boards/adafruit_feather.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_feather_dvi.json
+++ b/boards/adafruit_feather_dvi.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_feather_rfm.json
+++ b/boards/adafruit_feather_rfm.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_feather_scorpio.json
+++ b/boards/adafruit_feather_scorpio.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_feather_thinkink.json
+++ b/boards/adafruit_feather_thinkink.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_feather_usb_host.json
+++ b/boards/adafruit_feather_usb_host.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_itsybitsy.json
+++ b/boards/adafruit_itsybitsy.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_kb2040.json
+++ b/boards/adafruit_kb2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_macropad2040.json
+++ b/boards/adafruit_macropad2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_qtpy.json
+++ b/boards/adafruit_qtpy.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_stemmafriend.json
+++ b/boards/adafruit_stemmafriend.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/adafruit_trinkeyrp2040qt.json
+++ b/boards/adafruit_trinkeyrp2040qt.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/arduino_nano_connect.json
+++ b/boards/arduino_nano_connect.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/bridgetek_idm2040-7a.json
+++ b/boards/bridgetek_idm2040-7a.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/challenger_2040_lora.json
+++ b/boards/challenger_2040_lora.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/challenger_2040_lte.json
+++ b/boards/challenger_2040_lte.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/challenger_2040_nfc.json
+++ b/boards/challenger_2040_nfc.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/challenger_2040_sdrtc.json
+++ b/boards/challenger_2040_sdrtc.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/challenger_2040_subghz.json
+++ b/boards/challenger_2040_subghz.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/challenger_2040_uwb.json
+++ b/boards/challenger_2040_uwb.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/challenger_2040_wifi.json
+++ b/boards/challenger_2040_wifi.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/challenger_2040_wifi_ble.json
+++ b/boards/challenger_2040_wifi_ble.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/challenger_nb_2040_wifi.json
+++ b/boards/challenger_nb_2040_wifi.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/cytron_maker_nano_rp2040.json
+++ b/boards/cytron_maker_nano_rp2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/cytron_maker_pi_rp2040.json
+++ b/boards/cytron_maker_pi_rp2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/datanoisetv_picoadk.json
+++ b/boards/datanoisetv_picoadk.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/dfrobot_beetle_rp2040.json
+++ b/boards/dfrobot_beetle_rp2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/electroniccats_huntercat_nfc.json
+++ b/boards/electroniccats_huntercat_nfc.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/extelec_rc2040.json
+++ b/boards/extelec_rc2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/flyboard2040_core.json
+++ b/boards/flyboard2040_core.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/generic.json
+++ b/boards/generic.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/ilabs_rpico32.json
+++ b/boards/ilabs_rpico32.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/melopero_cookie_rp2040.json
+++ b/boards/melopero_cookie_rp2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/melopero_shake_rp2040.json
+++ b/boards/melopero_shake_rp2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/nekosystems_bl2040_mini.json
+++ b/boards/nekosystems_bl2040_mini.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/nullbits_bit_c_pro.json
+++ b/boards/nullbits_bit_c_pro.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/pico.json
+++ b/boards/pico.json
@@ -41,6 +41,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/pimoroni_pga2040.json
+++ b/boards/pimoroni_pga2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/rpipico.json
+++ b/boards/rpipico.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/rpipicow.json
+++ b/boards/rpipicow.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/seeed_xiao_rp2040.json
+++ b/boards/seeed_xiao_rp2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/solderparty_rp2040_stamp.json
+++ b/boards/solderparty_rp2040_stamp.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/sparkfun_promicrorp2040.json
+++ b/boards/sparkfun_promicrorp2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/sparkfun_thingplusrp2040.json
+++ b/boards/sparkfun_thingplusrp2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/upesy_rp2040_devkit.json
+++ b/boards/upesy_rp2040_devkit.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/vccgnd_yd_rp2040.json
+++ b/boards/vccgnd_yd_rp2040.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/viyalab_mizu.json
+++ b/boards/viyalab_mizu.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/waveshare_rp2040_lcd_0_96.json
+++ b/boards/waveshare_rp2040_lcd_0_96.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/waveshare_rp2040_lcd_1_28.json
+++ b/boards/waveshare_rp2040_lcd_1_28.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/waveshare_rp2040_one.json
+++ b/boards/waveshare_rp2040_one.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/waveshare_rp2040_plus_16mb.json
+++ b/boards/waveshare_rp2040_plus_16mb.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/waveshare_rp2040_plus_4mb.json
+++ b/boards/waveshare_rp2040_plus_4mb.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/waveshare_rp2040_zero.json
+++ b/boards/waveshare_rp2040_zero.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/wiznet_5100s_evb_pico.json
+++ b/boards/wiznet_5100s_evb_pico.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/wiznet_5500_evb_pico.json
+++ b/boards/wiznet_5500_evb_pico.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/boards/wiznet_wizfi360_evb_pico.json
+++ b/boards/wiznet_wizfi360_evb_pico.json
@@ -42,6 +42,7 @@
     "wait_for_upload_port": false,
     "protocol": "picotool",
     "protocols": [
+      "blackmagic",
       "cmsis-dap",
       "jlink",
       "raspberrypi-swd",

--- a/builder/main.py
+++ b/builder/main.py
@@ -381,6 +381,28 @@ if upload_protocol == "mbed":
         env.VerboseAction(AutodetectPicoDisk, "Looking for upload disk..."),
         env.VerboseAction(UploadUF2ToDisk, "Uploading $SOURCE")
     ]
+
+elif upload_protocol.startswith("blackmagic"):
+    env.Replace(
+        UPLOADER="$GDB",
+        UPLOADERFLAGS=[
+            "-nx",
+            "--batch",
+            "-ex", "target extended-remote $UPLOAD_PORT",
+            "-ex", "monitor %s_scan" %
+            ("jtag" if upload_protocol == "blackmagic-jtag" else "swdp"),
+            "-ex", "attach 1",
+            "-ex", "load",
+            "-ex", "compare-sections",
+            "-ex", "kill"
+        ],
+        UPLOADCMD="$UPLOADER $UPLOADERFLAGS $SOURCE"
+    )
+    upload_source = target_elf
+    upload_actions = [
+        env.VerboseAction(env.AutodetectUploadPort, "Looking for BlackMagic port..."),
+        env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")
+    ]
 elif upload_protocol == "espota":
     if not env.subst("$UPLOAD_PORT"):
         sys.stderr.write(

--- a/platform.py
+++ b/platform.py
@@ -89,8 +89,12 @@ class RaspberrypiPlatform(PlatformBase):
         for link in ("blackmagic", "cmsis-dap", "jlink", "raspberrypi-swd", "picoprobe"):
             if link not in upload_protocols or link in debug["tools"]:
                 continue
-
-            if link == "jlink":
+            if link == "blackmagic":
+                debug["tools"]["blackmagic"] = {
+                    "hwids": [["0x1d50", "0x6018"]],
+                    "require_debug_port": True
+                }
+            elif link == "jlink":
                 assert debug.get("jlink_device"), (
                     "Missed J-Link Device ID for %s" % board.id)
                 debug["tools"][link] = {

--- a/platform.py
+++ b/platform.py
@@ -86,7 +86,7 @@ class RaspberrypiPlatform(PlatformBase):
         if "tools" not in debug:
             debug["tools"] = {}
 
-        for link in ("cmsis-dap", "jlink", "raspberrypi-swd", "picoprobe"):
+        for link in ("blackmagic", "cmsis-dap", "jlink", "raspberrypi-swd", "picoprobe"):
             if link not in upload_protocols or link in debug["tools"]:
                 continue
 


### PR DESCRIPTION
Adds necessary platform code to facilitate uploading and debugging with the BlackMagicProbe, which recently became RP2040 capable.