### PR TITLE
change default picoprobe speed to 5000 kHz

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -499,9 +499,9 @@ elif upload_protocol in debug_tools:
     ]
     openocd_args.extend(
         debug_tools.get(upload_protocol).get("server").get("arguments", []))
-    # always use a default speed directive of 1000khz or an otherwise configured speed
+    # always use a default speed directive of 5000khz or an otherwise configured speed
     # otherwise, flash failures were observed
-    speed = env.GetProjectOption("debug_speed") or "1000"
+    speed = env.GetProjectOption("debug_speed") or "5000"
     openocd_args.extend(
         ["-c", "adapter speed %s" % speed]
     )


### PR DESCRIPTION
To make it the same as with the Arduino IDE
See https://github.com/earlephilhower/arduino-pico/pull/1218
Since it's the default on the Arduino-IDE I assume, this speed is very stable. Or is there a particular reason for this difference between Arduino IDE and PlatformIO?