### PR TITLE
Update Arduino-Pico core to 3.6.1

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -47,7 +47,7 @@
       "type": "framework",
       "optional": true,
       "owner": "earlephilhower",
-      "version": "https://github.com/earlephilhower/arduino-pico.git#41b0686aec4b0655e518e3ef98379131ad3773fa"
+      "version": "https://github.com/earlephilhower/arduino-pico.git#39a2bbd78811be87edac56b545d8b3a3b3b5bca4"
     },
     "tool-rp2040tools": {
       "type": "uploader",


### PR DESCRIPTION
Hi,

This PR upgrades the Arduino-Pico core to [3.6.1](https://github.com/earlephilhower/arduino-pico/releases/tag/3.6.1). I realise it's only been a few days, but I was looking for some of the new functionality (namely the HID polling rate options).

I've tested this on my own fork and everything seems to work fine, but let me know if there are any issues.