### PR TITLE
Advertise `upload` target as platform target / Fix Jetbrains Clion upload integration

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -537,7 +537,7 @@ elif upload_protocol == "custom":
 if not upload_actions:
     sys.stderr.write("Warning! Unknown upload protocol %s\n" % upload_protocol)
 
-AlwaysBuild(env.Alias("upload", upload_source, upload_actions))
+AlwaysBuild(env.AddPlatformTarget("upload", upload_source, upload_actions, "Default Upload"))
 env.AddPlatformTarget("uploadfs", target_firm, upload_actions, "Upload Filesystem Image")
 #
 # Default targets


### PR DESCRIPTION
**1. General Improvement**
Currently only platform targets are included in `pio project metadata` output. This output is backed by `__PIO_TARGETS` environment variable, which currently only includes explicit targets (e.g. added using `env.AddPlatformTarget`). Builtin targets are not included in this list. With one notable exception: For embedded platforms without explicit platform targets, [the `upload` target is added to the list.](https://github.com/platformio/platformio-core/blob/v6.1.14/platformio/builder/tools/piotarget.py#L97-L100)

There is already an platformio/platformio-core#4477 issue related to the `pio run --list-targets` output, which is backed by the metadata. The tickets requests a more complete output.

Nevertheless, the `upload` target is highly platform specific. So makes sense to not include this target if platform defines its own targets.

Therefore I'd like to request the raspberrypi platform to explicitly advertise its `upload` target by using `AddPlatformTarget("upload, ...)` instead of `Alias("upload", ...)`.

&nbsp;
**2. Side effect: Fixes Jetbrains Clion integration**
This also fixes broken Jetbrains Clion integration for the `upload` target of projects based on this raspberrypi platform:

Clion uses `pio project metadata` to figure out available targets. The *play* button of platformio run configurations is bound to the existance of the `upload` target in the metadata. If `upload` target is missing in `pio project metadata`, clicking the *play* button leads to error message `PlatformIO: Upload action is not available for this PlatformIO env`. Additionally the `upload` target and dependent actions won't show up in Clions PlatformIO pane.

