### PR TITLE
Add Raspberry Pi Pico 2W

### DIFF
--- a/boards/rpipico2w.json
+++ b/boards/rpipico2w.json
@@ -1,0 +1,55 @@
+{
+    "build": {
+        "arduino": {
+            "earlephilhower": {
+                "boot2_source": "none.S",
+                "usb_vid": "0x2E8A",
+                "usb_pid": "0x000F"
+            }
+        },
+        "core": "earlephilhower",
+        "cpu": "cortex-m33",
+        "extra_flags": "-DARDUINO_RASPBERRY_PI_PICO_2W -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500 -DPICO_CYW43_SUPPORTED=1",
+        "f_cpu": "150000000L",
+        "hwids": [
+            [
+                "0x2E8A",
+                "0x00C0"
+            ],
+            [
+                "0x2E8A",
+                "0x000F"
+            ]
+        ],
+        "mcu": "rp2350",
+        "variant": "rpipico2w"
+    },
+    "debug": {
+        "jlink_device": "RP2350_0",
+        "openocd_target": "rp2350.cfg",
+        "svd_path": "rp2350.svd"
+    },
+    "frameworks": [
+        "arduino"
+    ],
+    "name": "Pico 2W",
+    "upload": {
+        "maximum_ram_size": 524288,
+        "maximum_size": 4194304,
+        "require_upload_port": true,
+        "native_usb": true,
+        "use_1200bps_touch": true,
+        "wait_for_upload_port": false,
+        "protocol": "picotool",
+        "protocols": [
+            "blackmagic",
+            "cmsis-dap",
+            "jlink",
+            "raspberrypi-swd",
+            "picotool",
+            "picoprobe"
+        ]
+    },
+    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "vendor": "Pimoroni"
+}


### PR DESCRIPTION
Closes #86 


I've used the pimoroni pico plus 2w definition as a base, and used the rpipicow as a reference to update that base definition. Possibly extra things needed, but it builds, and connects to wifi and transmits data (Adafruit WipperSnapper firmware testing).