### PR TITLE
Add src/boards/include to CPPPATH

### DIFF
--- a/builder/frameworks/picosdk.py
+++ b/builder/frameworks/picosdk.py
@@ -72,7 +72,10 @@ env.Append(
         join(FRAMEWORK_DIR, "generated"),
         # this is 'genned_dir', but late-evaluated
         "$PROJECT_BUILD_DIR/$PIOENV/generated",
-
+        
+        # Boards Directory
+        join(FRAMEWORK_DIR, "src", "boards", "include"),
+        
         # Common for all (host, rp2040, rp2350)
         join(FRAMEWORK_DIR, "src", "common", "boot_picobin_headers", "include"),
         join(FRAMEWORK_DIR, "src", "common", "boot_picoboot_headers", "include"),


### PR DESCRIPTION
Adds `src/boards/include` to the include path. This should allow code that includes one of the board header files to compile normally.

I'm uncertian if including board header files is good practice, however it _is_ something the official SDK supports. 