### PR TITLE
Add Metro RP2350, latest bleeding edge version of arduino-pico

### DIFF
--- a/boards/adafruit_metro_rp2350.json
+++ b/boards/adafruit_metro_rp2350.json
@@ -1,0 +1,55 @@
+{
+    "build": {
+        "arduino": {
+            "earlephilhower": {
+                "boot2_source": "none.S",
+                "usb_vid": "0x239A",
+                "usb_pid": "0x814D"
+            }
+        },
+        "core": "earlephilhower",
+        "cpu": "cortex-m33",
+        "extra_flags": "-DARDUINO_ADAFRUIT_METRO_RP2350 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250 ",
+        "f_cpu": "125000000L",
+        "hwids": [
+            [
+                "0x2E8A",
+                "0x00C0"
+            ],
+            [
+                "0x239A",
+                "0x813D"
+            ]
+        ],
+        "mcu": "rp2350",
+        "variant": "adafruit_metro_rp2350"
+    },
+    "debug": {
+        "jlink_device": "RP2350_0",
+        "openocd_target": "rp2350.cfg",
+        "svd_path": "rp2350.svd"
+    },
+    "frameworks": [
+        "arduino"
+    ],
+    "name": "Metro RP2350",
+    "upload": {
+        "maximum_ram_size": 524288,
+        "maximum_size": 8388608,
+        "require_upload_port": true,
+        "native_usb": true,
+        "use_1200bps_touch": true,
+        "wait_for_upload_port": false,
+        "protocol": "picotool",
+        "protocols": [
+            "blackmagic",
+            "cmsis-dap",
+            "jlink",
+            "raspberrypi-swd",
+            "picotool",
+            "picoprobe"
+        ]
+    },
+    "url": "https://www.adafruit.com/product/6003",
+    "vendor": "Adafruit"
+}

--- a/platform.json
+++ b/platform.json
@@ -51,7 +51,7 @@
       "type": "framework",
       "optional": true,
       "owner": "earlephilhower",
-      "version": "https://github.com/earlephilhower/arduino-pico.git#b506c010f7766cfb181c8da6db93cb8d554460f6"
+      "version": "https://github.com/earlephilhower/arduino-pico.git#6236d1f7c599adf20c5b3a479e7232e2678c4fe2"
     },
     "framework-picosdk": {
       "type": "framework",


### PR DESCRIPTION
This pull request:
* Adds the new [Adafruit Metro RP2350](https://www.adafruit.com/product/6003) development board
* Updates the version of arduino-pico to the absolute latest (at time of writing this pull request) to include this board. The version of `arduino-pico` used by `platform-raspberry-pi` would update from v4.4.3 to a few commits after v4.4.4

cc @maxgerhardt 