### PR TITLE
Support RP2350 in builder/picosdk, added custom board for testing

### DIFF
--- a/boards/db_rp2350.json
+++ b/boards/db_rp2350.json
@@ -1,0 +1,55 @@
+{
+    "build": {
+        "arduino": {
+            "earlephilhower": {
+                "boot2_source": "none.S",
+                "usb_vid": "0x2E8A",
+                "usb_pid": "0xF00F"
+            }
+        },
+        "core": "earlephilhower",
+        "cpu": "cortex-m33",
+        "extra_flags": " ",
+        "f_cpu": "150000000L",
+        "hwids": [
+            [
+                "0x2E8A",
+                "0x00C0"
+            ],
+            [
+                "0x2E8A",
+                "0xF00F"
+            ]
+        ],
+        "mcu": "rp2350",
+        "variant": "db_rp2350"
+    },
+    "debug": {
+        "jlink_device": "RP2350_0",
+        "openocd_target": "rp2350.cfg",
+        "svd_path": "rp2350.svd"
+    },
+    "frameworks": [
+        "picosdk"
+    ],
+    "name": "RP2350",
+    "upload": {
+        "maximum_ram_size": 524288,
+        "maximum_size": 16777216,
+        "require_upload_port": true,
+        "native_usb": true,
+        "use_1200bps_touch": true,
+        "wait_for_upload_port": false,
+        "protocol": "picoprobe",
+        "protocols": [
+            "blackmagic",
+            "cmsis-dap",
+            "jlink",
+            "raspberrypi-swd",
+            "picotool",
+            "picoprobe"
+        ]
+    },
+    "url": "https://github.com/ece362-purdue",
+    "vendor": "DB-RP2350"
+}

--- a/builder/frameworks/picosdk.py
+++ b/builder/frameworks/picosdk.py
@@ -1,4 +1,4 @@
-from os.path import isdir, join
+from os.path import isdir, isfile, join
 from os import makedirs
 from pathlib import Path
 import sys
@@ -13,9 +13,12 @@ assert isdir(FRAMEWORK_DIR)
 
 mcu = "rp2350" if board.get('build.mcu') == "rp2350" else "rp2040"
 rp2_variant_dir = join(FRAMEWORK_DIR, "src", mcu)
-# todo: try to better guess the board header name based from the board definition name
-# instead of requiring them to explicitly include it
-rp2_board_header = board.get("build.picosdk.board_header", "pico.h")
+header = "%s.h" % board.get("build.variant")
+# try to find the board header in the common directory
+if isfile(join(FRAMEWORK_DIR, "src", "boards", "include", "boards", header)):
+    rp2_board_header = board.get("build.picosdk.board_header", header)
+else:
+    rp2_board_header = board.get("build.picosdk.board_header", "pico.h")
 
 # include basic settings
 env.SConscript("_bare.py")
@@ -32,10 +35,8 @@ def gen_config_autogen(target_base_dir, board_hdr):
         env.Exit(-1)
     autogen_content_paths = [
         join(FRAMEWORK_DIR, "src", "boards", "include", "boards", board_hdr),
-    ]
-    if mcu == "rp2040":
-        # only for ARM based RP2040
         join(FRAMEWORK_DIR, "src" , "rp2_common", "cmsis", "include", "cmsis", "rename_exceptions.h")
+    ]
     # read content
     autogen_content = ""
     for file in autogen_content_paths:
@@ -67,7 +68,7 @@ env.Append(
         ("PICO_ON_DEVICE", "1"),
         ("PICO_NO_HARDWARE", "0"),
         ("PICO_BUILD", "1"),
-        ("LIB_CMSIS_CORE", 1),
+        ("LIB_CMSIS_CORE", 1)
     ],
     CPPPATH=[
         # for version.h, one-time generated
@@ -100,8 +101,9 @@ env.Append(
         join(rp2_variant_dir, "boot_stage2", "include"),
 
         # common for rp2040, rp2350
-        join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_base", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "boot_bootrom_headers", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_adc", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_base", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_boot_lock", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_clocks", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_divider", "include"),
@@ -118,8 +120,8 @@ env.Append(
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_resets", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_rtc", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_spi", "include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_sync", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_sync_spin_lock", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_sync", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_ticks", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_timer", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_uart", "include"),
@@ -127,28 +129,28 @@ env.Append(
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_watchdog", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "hardware_xosc", "include"),
 
-        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_bootrom", "include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_platform_compiler", "include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_platform_sections", "include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_platform_panic", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_aon_timer", "include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_bootsel_via_double_reset", "include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_multicore", "include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_unique_id", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_atomic", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_bit_ops", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_bootrom", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_bootsel_via_double_reset", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_divider", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_double", "include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_int64_ops", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_flash", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_float", "include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_mem_ops", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_int64_ops", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_malloc", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_mem_ops", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_multicore", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_platform_compiler", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_platform_panic", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_platform_sections", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_printf", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_rand", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_stdio_rtt", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_stdio_semihosting", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_stdio_uart", "include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_stdio_rtt", "include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "pico_unique_id", "include"),
         # CMSIS only for ARM
         join(FRAMEWORK_DIR, "src", "rp2_common", "cmsis", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "cmsis", "stub", "CMSIS", "Core", "Include"),
@@ -197,6 +199,7 @@ env.Append(
 )
 
 cpp_defines = env.Flatten(env.get("CPPDEFINES", []))
+print("CPPDEFINES: ", cpp_defines)
 
 flags = []
 # configure default but overridable defines
@@ -208,6 +211,7 @@ if not "PICO_DEFAULT_BOOT_STAGE2" in cpp_defines:
 if not "PIO_NO_STDIO_UART" in cpp_defines:
     flags.append(("PICO_STDIO_UART", 1))
     # SDK C code specifies it as LIB_... so do that too
+    flags.append(("LIB_PICO_STDIO", 1))
     flags.append(("LIB_PICO_STDIO_UART", 1))
 if not "PIO_NO_MULTICORE" in cpp_defines:
     flags.append(("PICO_MULTICORE_ENABLED", 1))
@@ -324,23 +328,24 @@ env.Depends("$BUILD_DIR/${PROGNAME}.elf", gen_boot2_cmd)
 
 # default compontents
 default_common_rp2_components = [
-    ("pico_runtime_init", "+<*>"),
     ("hardware_adc", "+<*>"),
     ("hardware_boot_lock", "+<*>"),
     ("hardware_clocks", "+<*>"),
-    ("hardware_xosc", "+<*>"),
-    ("hardware_pll", "+<*>"),
-    ("hardware_ticks", "+<*>"),
-    ("hardware_uart", "+<*>"),
-    ("pico_clib_interface", "-<*> +<newlib_interface.c>"),
     ("hardware_gpio", "+<*>"),
-    ("hardware_timer", "+<*>"),
     ("hardware_irq", "+<*>"),
+    ("hardware_pll", "+<*>"),
     ("hardware_sync", "+<*>"),
     ("hardware_sync_spin_lock", "+<*>"),
+    ("hardware_ticks", "+<*>"),
+    ("hardware_timer", "+<*>"),
+    ("hardware_uart", "+<*>"),
+    ("hardware_xosc", "+<*>"),
+    ("pico_bootrom", "+<*>"),
+    ("pico_clib_interface", "-<*> +<newlib_interface.c>"),
     ("pico_platform_panic", "+<*>"),
     ("pico_runtime", "+<*>"),
-    ("pico_bootrom", "+<*>"),
+    ("pico_runtime_init", "+<*>"),
+    ("pico_stdlib", "+<*>"),
     ("pico_stdio", "+<*>"),
     ("pico_stdio_uart", "+<*>"),
 ]

--- a/builder/frameworks/picosdk.py
+++ b/builder/frameworks/picosdk.py
@@ -56,8 +56,8 @@ env.Append(
     #CFLAGS=sorted(list(cflags - ccflags)),
     #CCFLAGS=sorted(list(ccflags)),
     CPPDEFINES=[
-        # BUG: defining RP2040 in any way will force compilation for 2040 only.
-        # FIX: add RP2040 only if board requested was 2040
+        # BUG: defining PICO_RP2040 in any way will force compilation for 2040 only.
+        # FIX: add RP2350 only if board requested was 2350
         ("PICO_RP2350" if board.get('build.mcu') == "rp2350" else "PICO_RP2040", 1),
         ("PICO_RISCV", 0),
         ("PICO_ARM", 1),
@@ -152,7 +152,7 @@ env.Append(
         # CMSIS only for ARM
         join(FRAMEWORK_DIR, "src", "rp2_common", "cmsis", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "cmsis", "stub", "CMSIS", "Core", "Include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "cmsis", "stub", "CMSIS", "Device", "RP2350", "Include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "cmsis", "stub", "CMSIS", "Device", mcu.upper(), "Include"),
 
         join(FRAMEWORK_DIR, "src", "rp2_common", "tinyusb", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_stdio_usb", "include"),
@@ -179,7 +179,7 @@ env.Append(
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_stdio", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_stdlib", "include"),
 
-        join(FRAMEWORK_DIR, "src", "rp2350", "boot_stage2", "asminclude"),
+        join(FRAMEWORK_DIR, "src", mcu, "boot_stage2", "asminclude"),
     ],
     #CXXFLAGS=sorted(list(cxxflags - ccflags)),
     LIBPATH=[

--- a/builder/frameworks/picosdk.py
+++ b/builder/frameworks/picosdk.py
@@ -199,7 +199,6 @@ env.Append(
 )
 
 cpp_defines = env.Flatten(env.get("CPPDEFINES", []))
-print("CPPDEFINES: ", cpp_defines)
 
 flags = []
 # configure default but overridable defines

--- a/builder/frameworks/picosdk.py
+++ b/builder/frameworks/picosdk.py
@@ -11,8 +11,8 @@ board = env.BoardConfig()
 FRAMEWORK_DIR = platform.get_package_dir("framework-picosdk")
 assert isdir(FRAMEWORK_DIR)
 
-# hardcoded for now
-rp2_variant_dir = join(FRAMEWORK_DIR, "src", "rp2040")
+mcu = "rp2350" if board.get('build.mcu') == "rp2350" else "rp2040"
+rp2_variant_dir = join(FRAMEWORK_DIR, "src", mcu)
 # todo: try to better guess the board header name based from the board definition name
 # instead of requiring them to explicitly include it
 rp2_board_header = board.get("build.picosdk.board_header", "pico.h")
@@ -32,9 +32,10 @@ def gen_config_autogen(target_base_dir, board_hdr):
         env.Exit(-1)
     autogen_content_paths = [
         join(FRAMEWORK_DIR, "src", "boards", "include", "boards", board_hdr),
+    ]
+    if mcu == "rp2040":
         # only for ARM based RP2040
         join(FRAMEWORK_DIR, "src" , "rp2_common", "cmsis", "include", "cmsis", "rename_exceptions.h")
-    ]
     # read content
     autogen_content = ""
     for file in autogen_content_paths:
@@ -55,17 +56,18 @@ env.Append(
     #CFLAGS=sorted(list(cflags - ccflags)),
     #CCFLAGS=sorted(list(ccflags)),
     CPPDEFINES=[
-        ("PICO_RP2040", 1),
-        ("PICO_RP2350", 0),
+        # BUG: defining RP2040 in any way will force compilation for 2040 only.
+        # FIX: add RP2040 only if board requested was 2040
+        ("PICO_RP2350" if board.get('build.mcu') == "rp2350" else "PICO_RP2040", 1),
         ("PICO_RISCV", 0),
         ("PICO_ARM", 1),
-        ("PICO_CMSIS_DEVICE", "\"RP2040\""),
+        ("PICO_CMSIS_DEVICE", mcu.upper()),
         ("PICO_DEFAULT_FLASH_SIZE_BYTES", 2 * 1024 * 1024),
         # default SDK defines for on-hardware build
         ("PICO_ON_DEVICE", "1"),
         ("PICO_NO_HARDWARE", "0"),
         ("PICO_BUILD", "1"),
-        ("LIB_CMSIS_CORE", 1)
+        ("LIB_CMSIS_CORE", 1),
     ],
     CPPPATH=[
         # for version.h, one-time generated
@@ -150,7 +152,7 @@ env.Append(
         # CMSIS only for ARM
         join(FRAMEWORK_DIR, "src", "rp2_common", "cmsis", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "cmsis", "stub", "CMSIS", "Core", "Include"),
-        join(FRAMEWORK_DIR, "src", "rp2_common", "cmsis", "stub", "CMSIS", "Device", "RP2040", "Include"),
+        join(FRAMEWORK_DIR, "src", "rp2_common", "cmsis", "stub", "CMSIS", "Device", "RP2350", "Include"),
 
         join(FRAMEWORK_DIR, "src", "rp2_common", "tinyusb", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_stdio_usb", "include"),
@@ -177,7 +179,7 @@ env.Append(
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_stdio", "include"),
         join(FRAMEWORK_DIR, "src", "rp2_common", "pico_stdlib", "include"),
 
-        join(FRAMEWORK_DIR, "src", "rp2040", "boot_stage2", "asminclude"),
+        join(FRAMEWORK_DIR, "src", "rp2350", "boot_stage2", "asminclude"),
     ],
     #CXXFLAGS=sorted(list(cxxflags - ccflags)),
     LIBPATH=[
@@ -205,6 +207,8 @@ if not "PICO_DEFAULT_BOOT_STAGE2" in cpp_defines:
     pass
 if not "PIO_NO_STDIO_UART" in cpp_defines:
     flags.append(("PICO_STDIO_UART", 1))
+    # SDK C code specifies it as LIB_... so do that too
+    flags.append(("LIB_PICO_STDIO_UART", 1))
 if not "PIO_NO_MULTICORE" in cpp_defines:
     flags.append(("PICO_MULTICORE_ENABLED", 1))
 # check selected double implementation
@@ -231,9 +235,9 @@ if not "PIO_USE_DEFAULT_PAGE_SIZE" in cpp_defines:
     env.Append(LINKFLAGS=["-Wl,-z,max-page-size=4096"])
 
 timeout = 0
-if "PIO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS" in cpp_defines:
-    timeout = cpp_defines["PIO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS"]
-flags.append(("PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS", timeout))
+# if "PIO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS" in cpp_defines:
+#     timeout = cpp_defines["PIO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS"]
+# flags.append(("PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS", timeout))
 
 def build_double_library():
     pass
@@ -266,7 +270,7 @@ configure_printf_impl()
 flash_region = "FLASH(rx) : ORIGIN = 0x10000000, LENGTH = %s\n" % str(board.get("upload.maximum_size"))
 Path(join(genned_dir, "pico_flash_region.ld")).write_text(flash_region)
 
-env.Replace(LDSCRIPT_PATH=join(FRAMEWORK_DIR, "src", "rp2_common", "pico_crt0", "rp2040", "memmap_default.ld"))
+env.Replace(LDSCRIPT_PATH=join(FRAMEWORK_DIR, "src", "rp2_common", "pico_crt0", mcu, "memmap_default.ld"))
 
 # build base files
 # system_RP2040.c
@@ -277,7 +281,7 @@ env.Replace(LDSCRIPT_PATH=join(FRAMEWORK_DIR, "src", "rp2_common", "pico_crt0", 
 
 gen_boot2_cmd = env.Command(
     join("$BUILD_DIR", "boot2.S"),  # $TARGET
-    join(FRAMEWORK_DIR, "src", "rp2040", "boot_stage2", "compile_time_choice.S"),  # $SOURCE
+    join(FRAMEWORK_DIR, "src", mcu, "boot_stage2", "compile_time_choice.S"),  # $SOURCE
     env.VerboseAction(" ".join([
         "$CC",
         "$ASPPFLAGS",
@@ -286,8 +290,8 @@ gen_boot2_cmd = env.Command(
     ] 
     + ["-D%s=%s" % (flag[0], str(flag[1])) for flag in env["CPPDEFINES"]] 
     + [
-        "-I\"%s\"" % join(FRAMEWORK_DIR, "src", "rp2040", "boot_stage2", "asminclude"),
-        "-I\"%s\"" % join(FRAMEWORK_DIR, "src", "rp2040", "boot_stage2", "include"),
+        "-I\"%s\"" % join(FRAMEWORK_DIR, "src", mcu, "boot_stage2", "asminclude"),
+        "-I\"%s\"" % join(FRAMEWORK_DIR, "src", mcu, "boot_stage2", "include"),
         "-I\"%s\"" % join(FRAMEWORK_DIR, "src", "common", "pico_base_headers", "include"),
         "-I\"%s\"" % join(FRAMEWORK_DIR, "generated"),
         "-I", "$PROJECT_BUILD_DIR/$PIOENV/generated",
@@ -301,7 +305,7 @@ gen_boot2_cmd = env.Command(
         "-nostdlib",
         "--specs=nosys.specs",
         "-nostartfiles",
-        "-Wl,-T,\"%s\"" % join(FRAMEWORK_DIR, "src", "rp2040", "boot_stage2", "boot_stage2.ld"),
+        "-Wl,-T,\"%s\"" % join(FRAMEWORK_DIR, "src", mcu, "boot_stage2", "boot_stage2.ld"),
         "$SOURCE"
     ] + [ " && "] + [
         "$OBJCOPY",
@@ -310,7 +314,7 @@ gen_boot2_cmd = env.Command(
         join("$BUILD_DIR", "boot2.bin")
     ] + [ " && "] + [
         "$PYTHONEXE",
-        join(FRAMEWORK_DIR, "src", "rp2040", "boot_stage2", "pad_checksum"),
+        join(FRAMEWORK_DIR, "src", mcu, "boot_stage2", "pad_checksum"),
         "-s 0xffffffff",
         join("$BUILD_DIR", "boot2.bin"),
         join("$BUILD_DIR", "boot2.S"),
@@ -327,6 +331,7 @@ default_common_rp2_components = [
     ("hardware_xosc", "+<*>"),
     ("hardware_pll", "+<*>"),
     ("hardware_ticks", "+<*>"),
+    ("hardware_uart", "+<*>"),
     ("pico_clib_interface", "-<*> +<newlib_interface.c>"),
     ("hardware_gpio", "+<*>"),
     ("hardware_timer", "+<*>"),
@@ -335,6 +340,9 @@ default_common_rp2_components = [
     ("hardware_sync_spin_lock", "+<*>"),
     ("pico_platform_panic", "+<*>"),
     ("pico_runtime", "+<*>"),
+    ("pico_bootrom", "+<*>"),
+    ("pico_stdio", "+<*>"),
+    ("pico_stdio_uart", "+<*>"),
 ]
 
 for component, src_filter in default_common_rp2_components:

--- a/builder/frameworks/picosdk.py
+++ b/builder/frameworks/picosdk.py
@@ -61,7 +61,7 @@ env.Append(
         ("PICO_RP2350" if board.get('build.mcu') == "rp2350" else "PICO_RP2040", 1),
         ("PICO_RISCV", 0),
         ("PICO_ARM", 1),
-        ("PICO_CMSIS_DEVICE", mcu.upper()),
+        ("PICO_CMSIS_DEVICE", "\"%s\"" % mcu.upper()),
         ("PICO_DEFAULT_FLASH_SIZE_BYTES", 2 * 1024 * 1024),
         # default SDK defines for on-hardware build
         ("PICO_ON_DEVICE", "1"),
@@ -235,9 +235,9 @@ if not "PIO_USE_DEFAULT_PAGE_SIZE" in cpp_defines:
     env.Append(LINKFLAGS=["-Wl,-z,max-page-size=4096"])
 
 timeout = 0
-# if "PIO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS" in cpp_defines:
-#     timeout = cpp_defines["PIO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS"]
-# flags.append(("PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS", timeout))
+if "PIO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS" in cpp_defines:
+    timeout = cpp_defines["PIO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS"]
+flags.append(("PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS", timeout))
 
 def build_double_library():
     pass


### PR DESCRIPTION
Hi all,

Thank you for all your hard work!  This is one of my first PRs to the wider open-source community so please let me know if there is anything important I missed.

I am interested in porting over our embedded systems course labs to the RP2350 platform, but we need to use the Pico SDK instead of the Arduino framework.  I designed a custom development board + debugger for the RP2350B variant which I would like to develop support for on PlatformIO, which we've used successfully so far for the STM32F091RCT6 custom board we have.  

Off the bat, @maxgerhardt's repo didn't seem to compile for the RP2350, so I made some changes to the builder/picosdk script that makes it compile for RP2350 while (hopefully) still maintaining support for the RP2040.  I've attached a MVE for reference.  Theoretically, this should work with a Pico 2 and the official Debug Probe attached, as well.

[pio-test.zip](https://github.com/user-attachments/files/19552775/pio-test.zip)

I also added our custom board (db_rp2350) since none of the other files have picosdk listed as a supported framework.

What works in this commit:
- Switching between RP2350/RP2040 by using `board_build.mcu` in PIO options.
- Build/Upload to our board with the `picoprobe` option.
- Basic debugging (inspecting variables, watch statements)
- ARM-only (will add RISC-V later on)

What I'm having trouble with (that I could use some advice on):
- UART via our debugger doesn't seem to work even though it works just fine with the Pico extension.  My guess is that the necessary libraries aren't getting included properly.
    - Solved further down!
- SVD file parsing by the Peripherals view while debugging is broken ("TypeError: cannot read properties of undefined, reading 0") which seems to be a widely known issue, not just with the RP2xxx SVDs.