### PR TITLE
Correct build.variant to match pico-sdk names

### DIFF
--- a/boards/waveshare_rp2040_lcd_0_96.json
+++ b/boards/waveshare_rp2040_lcd_0_96.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2040-lcd-0.96.htm",
     "vendor": "Waveshare"
 }

--- a/boards/waveshare_rp2040_lcd_0_96.json
+++ b/boards/waveshare_rp2040_lcd_0_96.json
@@ -22,7 +22,7 @@
             ]
         ],
         "mcu": "rp2040",
-        "variant": "waveshare_rp2040_lcd_0_96"
+        "variant": "waveshare_rp2040_lcd_0.96"
     },
     "debug": {
         "jlink_device": "RP2040_M0_0",

--- a/boards/waveshare_rp2040_lcd_1_28.json
+++ b/boards/waveshare_rp2040_lcd_1_28.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2040-lcd-1.28.htm",
     "vendor": "Waveshare"
 }

--- a/boards/waveshare_rp2040_lcd_1_28.json
+++ b/boards/waveshare_rp2040_lcd_1_28.json
@@ -22,7 +22,7 @@
             ]
         ],
         "mcu": "rp2040",
-        "variant": "waveshare_rp2040_lcd_1_28"
+        "variant": "waveshare_rp2040_lcd_1.28"
     },
     "debug": {
         "jlink_device": "RP2040_M0_0",

--- a/boards/waveshare_rp2040_matrix.json
+++ b/boards/waveshare_rp2040_matrix.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2040-matrix.htm",
     "vendor": "Waveshare"
 }

--- a/boards/waveshare_rp2040_one.json
+++ b/boards/waveshare_rp2040_one.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2040-one.htm",
     "vendor": "Waveshare"
 }

--- a/boards/waveshare_rp2040_pizero.json
+++ b/boards/waveshare_rp2040_pizero.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2040-pizero.htm",
     "vendor": "Waveshare"
 }

--- a/boards/waveshare_rp2040_plus.json
+++ b/boards/waveshare_rp2040_plus.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2040-plus.htm",
     "vendor": "Waveshare"
 }

--- a/boards/waveshare_rp2040_plus_16mb.json
+++ b/boards/waveshare_rp2040_plus_16mb.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2040-plus.htm",
     "vendor": "Waveshare"
 }

--- a/boards/waveshare_rp2040_plus_4mb.json
+++ b/boards/waveshare_rp2040_plus_4mb.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2040-plus.htm",
     "vendor": "Waveshare"
 }

--- a/boards/waveshare_rp2040_zero.json
+++ b/boards/waveshare_rp2040_zero.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2040-zero.htm",
     "vendor": "Waveshare"
 }

--- a/boards/waveshare_rp2350_lcd_0_96.json
+++ b/boards/waveshare_rp2350_lcd_0_96.json
@@ -22,7 +22,7 @@
             ]
         ],
         "mcu": "rp2350",
-        "variant": "waveshare_rp2350_lcd_0_96"
+        "variant": "waveshare_rp2350_lcd_0.96"
     },
     "debug": {
         "jlink_device": "RP2350_M33_0",

--- a/boards/waveshare_rp2350_lcd_0_96.json
+++ b/boards/waveshare_rp2350_lcd_0_96.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2350-lcd-0.96.htm",
     "vendor": "Waveshare"
 }

--- a/boards/waveshare_rp2350_plus.json
+++ b/boards/waveshare_rp2350_plus.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2350-plus.htm",
     "vendor": "Waveshare"
 }

--- a/boards/waveshare_rp2350_zero.json
+++ b/boards/waveshare_rp2350_zero.json
@@ -51,6 +51,6 @@
             "picoprobe"
         ]
     },
-    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "url": "https://www.waveshare.com/rp2350-zero.htm",
     "vendor": "Waveshare"
 }


### PR DESCRIPTION
In pidosdk.py:19 the check for header
  isfile(join(FRAMEWORK_DIR, "src", "boards", "include", "boards", header)):
fails, as pico-sdk names boards using the dot.

Otherwise (and without warning) the pico.h header is chosen, leading to false assumptions (e.g. about PICO_DEFAULT_LED_PIN)