### PR TITLE
Board definition for Olimex Pico2bb48r

### DIFF
--- a/boards/olimex_pico2bb48r.json
+++ b/boards/olimex_pico2bb48r.json
@@ -33,7 +33,7 @@
         "arduino",
         "picosdk"
     ],
-    "name": "Pico2BB48",
+    "name": "Pico2BB48R",
     "upload": {
         "maximum_ram_size": 524288,
         "maximum_size": 16777216,

--- a/boards/olimex_pico2bb48r.json
+++ b/boards/olimex_pico2bb48r.json
@@ -22,7 +22,7 @@
             ]
         ],
         "mcu": "rp2350",
-        "variant": "olimex_pico2bb48r"
+        "variant": "olimex_pico2bb48"
     },
     "debug": {
         "jlink_device": "RP2350_M33_0",

--- a/boards/olimex_pico2bb48r.json
+++ b/boards/olimex_pico2bb48r.json
@@ -1,0 +1,59 @@
+{
+    "build": {
+        "arduino": {
+            "earlephilhower": {
+                "boot2_source": "none.S",
+                "usb_vid": "0x15BA",
+                "usb_pid": "0x0026"
+            }
+        },
+        "core": "earlephilhower",
+        "cpu": "cortex-m33",
+        "extra_flags": "-DARDUINO_OLIMEX_PICO2BB48 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500 ",
+        "f_cpu": "150000000L",
+        "hwids": [
+            [
+                "0x2E8A",
+                "0x00C0"
+            ],
+            [
+                "0x15BA",
+                "0x0026"
+            ]
+        ],
+        "mcu": "rp2350",
+        "variant": "olimex_pico2bb48"
+    },
+    "debug": {
+        "jlink_device": "RP2350_M33_0",
+        "openocd_target": "rp2350.cfg",
+        "svd_path": "rp2350.svd"
+    },
+    "frameworks": [
+        "arduino",
+        "picosdk"
+    ],
+    "name": "Pico2BB48",
+    "upload": {
+        "maximum_ram_size": 524288,
+        "maximum_size": 16777216,
+        "require_upload_port": true,
+        "native_usb": true,
+        "use_1200bps_touch": true,
+        "wait_for_upload_port": false,
+        "protocol": "picotool",
+        "protocols": [
+            "blackmagic",
+            "cmsis-dap",
+            "jlink",
+            "raspberrypi-swd",
+            "picotool",
+            "picoprobe"
+        ],
+        "psram_length": 8388608,
+        "pico_psram_size": 8,
+        "pico_boot2_name": "boot2_psram8.S"
+    },
+    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "vendor": "Olimex"
+}

--- a/boards/olimex_pico2bb48r.json
+++ b/boards/olimex_pico2bb48r.json
@@ -22,7 +22,7 @@
             ]
         ],
         "mcu": "rp2350",
-        "variant": "olimex_pico2bb48"
+        "variant": "olimex_pico2bb48r"
     },
     "debug": {
         "jlink_device": "RP2350_M33_0",


### PR DESCRIPTION
A simple duplication of the BB48 board def, with PSRAM config added.

`board = olimex_pico2bb48r`

https://www.olimex.com/Products/RaspberryPi/PICO/RP2350-PICO2-BB48/open-source-hardware